### PR TITLE
Fix README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![TextDistance logo](logo.png)
 
-[![Build Status](https://travis-ci.org/orsinium/textdistance.svg?branch=master)](https://travis-ci.org/orsinium/textdistance) [![PyPI version](https://img.shields.io/pypi/v/textdistance.svg)](https://pypi.python.org/pypi/textdistance) [![Status](https://img.shields.io/pypi/status/textdistance.svg)](https://pypi.python.org/pypi/textdistance) [![Code size](https://img.shields.io/github/languages/code-size/orsinium/textdistance.svg)](https://github.com/orsinium/textdistance) [![License](https://img.shields.io/pypi/l/textdistance.svg)](LICENSE)
+[![Build Status](https://travis-ci.org/life4/textdistance.svg?branch=master)](https://travis-ci.org/life4/textdistance) [![PyPI version](https://img.shields.io/pypi/v/textdistance.svg)](https://pypi.python.org/pypi/textdistance) [![Status](https://img.shields.io/pypi/status/textdistance.svg)](https://pypi.python.org/pypi/textdistance) [![Code size](https://img.shields.io/github/languages/code-size/life4/textdistance.svg)](https://github.com/life4/textdistance) [![License](https://img.shields.io/pypi/l/textdistance.svg)](LICENSE)
 
 **TextDistance** -- python library for comparing distance between two or more sequences by many algorithms.
 
@@ -134,13 +134,13 @@ Algorithms with available extras: `DamerauLevenshtein`, `Hamming`, `Jaro`, `Jaro
 Via pip:
 
 ```bash
-pip install -e git+https://github.com/orsinium/textdistance.git#egg=textdistance
+pip install -e git+https://github.com/life4/textdistance.git#egg=textdistance
 ```
 
 Or clone repo and install with some extras:
 
 ```bash
-git clone https://github.com/orsinium/textdistance.git
+git clone https://github.com/life4/textdistance.git
 pip install -e ".[benchmark]"
 ```
 

--- a/README.rst
+++ b/README.rst
@@ -197,13 +197,13 @@ Via pip:
 
 .. code:: bash
 
-    pip install -e git+https://github.com/orsinium/textdistance.git#egg=textdistance
+    pip install -e git+https://github.com/life4/textdistance.git#egg=textdistance
 
 Or clone repo and install with some extras:
 
 .. code:: bash
 
-    git clone https://github.com/orsinium/textdistance.git
+    git clone https://github.com/life4/textdistance.git
     pip install -e ".[benchmark]"
 
 Usage
@@ -418,13 +418,13 @@ You can run tests via `tox <https://tox.readthedocs.io/en/latest/>`__:
     sudo pip3 install tox
     tox
 
-.. |Build Status| image:: https://travis-ci.org/orsinium/textdistance.svg?branch=master
-   :target: https://travis-ci.org/orsinium/textdistance
+.. |Build Status| image:: https://travis-ci.org/life4/textdistance.svg?branch=master
+   :target: https://travis-ci.org/life4/textdistance
 .. |PyPI version| image:: https://img.shields.io/pypi/v/textdistance.svg
    :target: https://pypi.python.org/pypi/textdistance
 .. |Status| image:: https://img.shields.io/pypi/status/textdistance.svg
    :target: https://pypi.python.org/pypi/textdistance
-.. |Code size| image:: https://img.shields.io/github/languages/code-size/orsinium/textdistance.svg
-   :target: https://github.com/orsinium/textdistance
+.. |Code size| image:: https://img.shields.io/github/languages/code-size/life4/textdistance.svg
+   :target: https://github.com/life4/textdistance
 .. |License| image:: https://img.shields.io/pypi/l/textdistance.svg
    :target: LICENSE


### PR DESCRIPTION
Hi,

Noticed that the Travis CI link was wrong. Then found a few more links that appear to reference an old repository.

This PR tries to correct the links by replacing orsinium by life4 in some URL's.

And thanks for the great project,
Bruno