### PR TITLE
Revision of urls in class docstrings and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Features:
 | [Tanimoto distance](https://en.wikipedia.org/wiki/Jaccard_index#Tanimoto_similarity_and_distance) | `Tanimoto`   | `tanimoto`   |
 | [Cosine similarity](https://en.wikipedia.org/wiki/Cosine_similarity)                      | `Cosine`             | `cosine`     |
 | [Monge-Elkan](https://www.academia.edu/200314/Generalized_Monge-Elkan_Method_for_Approximate_Text_String_Comparison) | `MongeElkan` | `monge_elkan` |
-| [Bag distance](https://github.com/Yomguithereal/talisman/blob/master/src/metrics/distance/bag.js) | `Bag`        | `bag`        |
+| [Bag distance](https://github.com/Yomguithereal/talisman/blob/master/src/metrics/bag.js) | `Bag`        | `bag`        |
 
 ### Sequence based
 

--- a/textdistance/algorithms/edit_based.py
+++ b/textdistance/algorithms/edit_based.py
@@ -226,8 +226,8 @@ class JaroWinkler(_BaseSimilarity):
     and thus are likely to match.
 
     https://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance
-    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/distance/jaro.js
-    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/distance/jaro-winkler.js
+    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/jaro.js
+    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/jaro-winkler.js
     """
     def __init__(self, long_tolerance=False, winklerize=True, qval=1, external=True):
         self.qval = qval
@@ -419,7 +419,7 @@ class SmithWaterman(_BaseSimilarity):
     segments of all possible lengths and optimizes the similarity measure.
 
     https://en.wikipedia.org/wiki/Smith%E2%80%93Waterman_algorithm
-    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/distance/smith-waterman.js
+    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/smith-waterman.js
     """
     def __init__(self, gap_cost=1.0, sim_func=None, qval=1, external=True):
         self.qval = qval
@@ -684,7 +684,7 @@ class MLIPNS(_BaseSimilarity):
     The Hamming distance is the number of differing items in ordered sequences.
 
     http://www.sial.iias.spb.su/files/386-386-1-PB.pdf
-    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/distance/mlipns.js
+    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/mlipns.js
     """
     def __init__(self, threshold=0.25, maxmismatches=2, qval=1, external=True):
         self.qval = qval

--- a/textdistance/algorithms/phonetic.py
+++ b/textdistance/algorithms/phonetic.py
@@ -25,7 +25,7 @@ __all__ = [
 class MRA(_BaseSimilarity):
     """Western Airlines Surname Match Rating Algorithm comparison rating
     https://en.wikipedia.org/wiki/Match_rating_approach
-    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/distance/mra.js
+    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/mra.js
     """
 
     def maximum(self, *sequences):

--- a/textdistance/algorithms/sequence_based.py
+++ b/textdistance/algorithms/sequence_based.py
@@ -141,7 +141,7 @@ class RatcliffObershelp(_BaseSimilarity):
            sequences.
 
     https://en.wikipedia.org/wiki/Gestalt_Pattern_Matching
-    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/distance/ratcliff-obershelp.js
+    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/ratcliff-obershelp.js
     https://xlinux.nist.gov/dads/HTML/ratcliffObershelp.html
     """
 

--- a/textdistance/algorithms/token_based.py
+++ b/textdistance/algorithms/token_based.py
@@ -25,7 +25,7 @@ class Jaccard(_BaseSimilarity):
     and 0 totally different.
 
     https://en.wikipedia.org/wiki/Jaccard_index
-    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/distance/jaccard.js
+    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/jaccard.js
     """
     def __init__(self, qval=1, as_set=False, external=True):
         self.qval = qval
@@ -56,7 +56,7 @@ class Sorensen(_BaseSimilarity):
     and 1 totally different.
 
     https://en.wikipedia.org/wiki/S%C3%B8rensen%E2%80%93Dice_coefficient
-    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/distance/dice.js
+    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/dice.js
     """
     def __init__(self, qval=1, as_set=False, external=True):
         self.qval = qval
@@ -82,7 +82,7 @@ class Tversky(_BaseSimilarity):
     """Tversky index
 
     https://en.wikipedia.org/wiki/Tversky_index
-    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/distance/tversky.js
+    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/tversky.js
     """
     def __init__(self, qval=1, ks=None, bias=None, as_set=False, external=True):
         self.qval = qval
@@ -124,7 +124,7 @@ class Overlap(_BaseSimilarity):
     """overlap coefficient
 
     https://en.wikipedia.org/wiki/Overlap_coefficient
-    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/distance/overlap.js
+    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/overlap.js
     """
     def __init__(self, qval=1, as_set=False, external=True):
         self.qval = qval
@@ -151,7 +151,7 @@ class Cosine(_BaseSimilarity):
     """cosine similarity (Ochiai coefficient)
 
     https://en.wikipedia.org/wiki/Cosine_similarity
-    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/distance/cosine.js
+    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/cosine.js
     """
     def __init__(self, qval=1, as_set=False, external=True):
         self.qval = qval
@@ -192,7 +192,7 @@ class MongeElkan(_BaseSimilarity):
     """
     https://www.academia.edu/200314/Generalized_Monge-Elkan_Method_for_Approximate_Text_String_Comparison
     http://www.cs.cmu.edu/~wcohen/postscript/kdd-2003-match-ws.pdf
-    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/distance/monge-elkan.js
+    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/monge-elkan.js
     """
     _damerau_levenshtein = DamerauLevenshtein()
 
@@ -238,7 +238,7 @@ class MongeElkan(_BaseSimilarity):
 
 class Bag(_Base):
     """Bag distance
-    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/distance/bag.js
+    https://github.com/Yomguithereal/talisman/blob/master/src/metrics/bag.js
     """
     def __call__(self, *sequences):
         sequences = self._get_counters(*sequences)              # sets


### PR DESCRIPTION
Now redirecting correctly to new folder structure for talisman both in the documentation and in classes' docstrings.