### PR TITLE
Fix numpy types warnings

### DIFF
--- a/textdistance/algorithms/edit_based.py
+++ b/textdistance/algorithms/edit_based.py
@@ -392,7 +392,7 @@ class NeedlemanWunsch(_BaseSimilarity):
 
         dist_mat = numpy.zeros(
             (len(s1) + 1, len(s2) + 1),
-            dtype=numpy.float,
+            dtype=float,
         )
         # DP initialization
         for i in range(len(s1) + 1):
@@ -442,7 +442,7 @@ class SmithWaterman(_BaseSimilarity):
 
         dist_mat = numpy.zeros(
             (len(s1) + 1, len(s2) + 1),
-            dtype=numpy.float,
+            dtype=float,
         )
         for i, sc1 in enumerate(s1, start=1):
             for j, sc2 in enumerate(s2, start=1):
@@ -491,9 +491,9 @@ class Gotoh(NeedlemanWunsch):
 
         len_s1 = len(s1)
         len_s2 = len(s2)
-        d_mat = numpy.zeros((len_s1 + 1, len_s2 + 1), dtype=numpy.float)
-        p_mat = numpy.zeros((len_s1 + 1, len_s2 + 1), dtype=numpy.float)
-        q_mat = numpy.zeros((len_s1 + 1, len_s2 + 1), dtype=numpy.float)
+        d_mat = numpy.zeros((len_s1 + 1, len_s2 + 1), dtype=float)
+        p_mat = numpy.zeros((len_s1 + 1, len_s2 + 1), dtype=float)
+        q_mat = numpy.zeros((len_s1 + 1, len_s2 + 1), dtype=float)
 
         d_mat[0, 0] = 0
         p_mat[0, 0] = float('-inf')

--- a/textdistance/algorithms/edit_based.py
+++ b/textdistance/algorithms/edit_based.py
@@ -137,7 +137,7 @@ class DamerauLevenshtein(_Base):
 
     def _numpy(self, s1, s2):
         # TODO: doesn't pass tests, need improve
-        d = numpy.zeros([len(s1) + 1, len(s2) + 1], dtype=numpy.int)
+        d = numpy.zeros([len(s1) + 1, len(s2) + 1], dtype=int)
 
         # matrix
         for i in range(-1, len(s1) + 1):

--- a/textdistance/algorithms/phonetic.py
+++ b/textdistance/algorithms/phonetic.py
@@ -142,7 +142,7 @@ class Editex(_Base):
         len_s1 = len(s1) - 1
         len_s2 = len(s2) - 1
         if numpy:
-            d_mat = numpy.zeros((len_s1 + 1, len_s2 + 1), dtype=numpy.int)
+            d_mat = numpy.zeros((len_s1 + 1, len_s2 + 1), dtype=int)
         else:
             d_mat = defaultdict(lambda: defaultdict(int))
 

--- a/textdistance/algorithms/sequence_based.py
+++ b/textdistance/algorithms/sequence_based.py
@@ -36,7 +36,7 @@ class LCSSeq(_BaseSimilarity):
         http://rosettacode.org/wiki/Longest_common_subsequence#Dynamic_Programming_8
         """
         if numpy:
-            lengths = numpy.zeros((len(seq1) + 1, len(seq2) + 1), dtype=numpy.int)
+            lengths = numpy.zeros((len(seq1) + 1, len(seq2) + 1), dtype=int)
         else:
             lengths = [array('L', [0] * (len(seq2) + 1)) for _ in range(len(seq1) + 1)]
 


### PR DESCRIPTION
Basic types have been deprecated in numpy 1.20. Here are the full warnings:
```
DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use `int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```
```
DeprecationWarning: `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```
I don’t know the code enough to assess if the specific numpy types are required though.