### PR TITLE
Ensure that maximum normalised distance is <= 1 and ...

### DIFF
--- a/tests/test_edit/test_editex.py
+++ b/tests/test_edit/test_editex.py
@@ -27,7 +27,7 @@ def test_distance(left, right, expected):
 
 @pytest.mark.parametrize('left, right, params, expected', [
     ('MARTHA', 'MARHTA', dict(match_cost=2), 12),
-    ('MARTHA', 'MARHTA', dict(match_cost=4), 14),
+    ('MARTHA', 'MARHTA', dict(match_cost=4), 24),
     ('MARTHA', 'MARHTA', dict(group_cost=1, local=True), 3),
     ('MARTHA', 'MARHTA', dict(group_cost=2, local=True), 4),
     ('MARTHA', 'MARHTA', dict(mismatch_cost=4, local=True), 5),

--- a/textdistance/algorithms/edit_based.py
+++ b/textdistance/algorithms/edit_based.py
@@ -557,12 +557,6 @@ class StrCmp95(_BaseSimilarity):
         return 0 < ord(char) < 91
 
     def __call__(self, s1, s2):
-        # Doing `upper` might result in some one-char lowercase glyphs
-        # being represented as two chars in uppercase, which in turn
-        # might result in a distance that is greater than the maximum
-        # input sequence length.  We therefore save that maximum first,
-        # and do not return a distance greater than it.
-        max_length = self.maximum(s1, s2)
         s1 = s1.strip().upper()
         s2 = s2.strip().upper()
 
@@ -673,16 +667,16 @@ class StrCmp95(_BaseSimilarity):
         # After agreeing beginning chars, at least two more must agree and
         # the agreeing characters must be > .5 of remaining characters.
         if not self.long_strings:
-            return min(weight, max_length)
+            return weight
         if minv <= 4:
-            return min(weight, max_length)
+            return weight
         if num_com <= i + 1 or 2 * num_com < minv + i:
-            return min(weight, max_length)
+            return weight
         if s1[0].isdigit():
-            return min(weight, max_length)
+            return weight
         res = (num_com - i - 1) / (len_s1 + len_s2 - i * 2 + 2)
         weight += (1.0 - weight) * res
-        return min(weight, max_length)
+        return weight
 
 
 class MLIPNS(_BaseSimilarity):

--- a/textdistance/algorithms/edit_based.py
+++ b/textdistance/algorithms/edit_based.py
@@ -557,6 +557,12 @@ class StrCmp95(_BaseSimilarity):
         return 0 < ord(char) < 91
 
     def __call__(self, s1, s2):
+        # Doing `upper` might result in some one-char lowercase glyphs
+        # being represented as two chars in uppercase, which in turn
+        # might result in a distance that is greater than the maximum
+        # input sequence length.  We therefore save that maximum first,
+        # and do not return a distance greater than it.
+        max_length = self.maximum(s1, s2)
         s1 = s1.strip().upper()
         s2 = s2.strip().upper()
 
@@ -667,16 +673,16 @@ class StrCmp95(_BaseSimilarity):
         # After agreeing beginning chars, at least two more must agree and
         # the agreeing characters must be > .5 of remaining characters.
         if not self.long_strings:
-            return weight
+            return min(weight, max_length)
         if minv <= 4:
-            return weight
+            return min(weight, max_length)
         if num_com <= i + 1 or 2 * num_com < minv + i:
-            return weight
+            return min(weight, max_length)
         if s1[0].isdigit():
-            return weight
+            return min(weight, max_length)
         res = (num_com - i - 1) / (len_s1 + len_s2 - i * 2 + 2)
         weight += (1.0 - weight) * res
-        return weight
+        return min(weight, max_length)
 
 
 class MLIPNS(_BaseSimilarity):

--- a/textdistance/algorithms/phonetic.py
+++ b/textdistance/algorithms/phonetic.py
@@ -95,9 +95,10 @@ class Editex(_Base):
 
     def __init__(self, local=False, match_cost=0, group_cost=1, mismatch_cost=2,
                  groups=None, ungrouped=None, external=True):
+        # Ensure that match_cost <= group_cost <= mismatch_cost
         self.match_cost = match_cost
-        self.group_cost = group_cost
-        self.mismatch_cost = mismatch_cost
+        self.group_cost = max(group_cost, self.match_cost)
+        self.mismatch_cost = max(mismatch_cost, self.group_cost)
         self.local = local
         self.external = external
 
@@ -137,6 +138,9 @@ class Editex(_Base):
 
         # must do `upper` before getting length because some one-char lowercase glyphs
         # are represented as two chars in uppercase.
+        # This might result in a distance that is greater than the maximum
+        # input sequence length, though, so we save that maximum first.
+        max_length = self.maximum(s1, s2)
         s1 = ' ' + s1.upper()
         s2 = ' ' + s2.upper()
         len_s1 = len(s1) - 1
@@ -160,7 +164,8 @@ class Editex(_Base):
                     d_mat[i - 1][j - 1] + self.r_cost(cs1_curr, cs2_curr),
                 )
 
-        return d_mat[len_s1][len_s2]
+        distance = d_mat[len_s1][len_s2]
+        return min(distance, max_length)
 
 
 mra = MRA()


### PR DESCRIPTION
textdistance is currently failing its test-suite on arm64 machines with Python 3.10, which is causing me problems on Debian.  I have managed to track down the first of these bugs (and there are at least two more to come): there are some algorithms that use `upper()` before comparing the strings. As noted in the code already, though these algorithms were designed for English (ASCII only), this can cause `upper()` to change the length of the string if using non-English characters. And `hypothesis` does this when testing. This can result in the normalised distance being greater than 1. This patch addresses this by ensuring that the distance returned from the relevant algorithms is no greater than `self.maximum()`.

A second issue which arose when doing this was calculating the maximum distance for `Editex()`; the current function for calculating the maximum does not give the correct answer if `match_cost > mismatch_cost`, for example. But this would be a silly situation: why would we penalise matching characters more than mismatching ones? There are two ways of resolving this: the first is to calculate the maximum distance using `max(match_cost, group_cost, mismatch_cost)`, the second is to force the inequalities `match_cost <= group_cost <= mismatch_cost`.  I have gone for the latter option in this patch.

All being well, there will be more patches to come in the next few weeks as I get to the bottom of them!