### PR TITLE
Ignore inconsistent timings on some comparison tests

### DIFF
--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -77,6 +77,7 @@ def test_normalization_same(text, alg):
 
 
 @pytest.mark.parametrize('alg', ALGS)
+@hypothesis.settings(deadline=None)
 @hypothesis.given(
     left=hypothesis.strategies.text(min_size=1),
     right=hypothesis.strategies.text(min_size=1),

--- a/tests/test_external.py
+++ b/tests/test_external.py
@@ -15,6 +15,7 @@ libraries = prototype.clone()
 
 @pytest.mark.external
 @pytest.mark.parametrize('alg', libraries.get_algorithms())
+@hypothesis.settings(deadline=None)
 @hypothesis.given(
     left=hypothesis.strategies.text(min_size=1),
     right=hypothesis.strategies.text(min_size=1),


### PR DESCRIPTION
Two particular tests have timings that differ wildly between successive runs on arm64 architectures. This might be because some libraries take a long time to load or something like that - I don't know. But this patch turns off hypothesis's timing checks for these two tests. I'm going to apply it to Debian's package; you might or might not want to apply it upstream.