### PR TITLE
Possible correction to Monge-Elkan calculation

### DIFF
--- a/textdistance/algorithms/token_based.py
+++ b/textdistance/algorithms/token_based.py
@@ -219,7 +219,8 @@ class MongeElkan(_BaseSimilarity):
                 for c2 in s:
                     max_sim = max(max_sim, self.algorithm.similarity(c1, c2))
                 maxes.append(max_sim)
-        return sum(maxes) / len(seq) / len(maxes)
+#         return sum(maxes) / len(seq) / len(maxes)
+        return sum(maxes) / len(seq)
 
     def __call__(self, *sequences):
         result = self.quick_answer(*sequences)


### PR DESCRIPTION
Might be wrong about this, but think the code for the Monge-Elkan
algorithm needs to be corrected. 

If you look at the implementation in the py_stringmatching library on line 81 of 
https://github.com/anhaidgroup/py_stringmatching/blob/master/py_stringmatching/similarity_measure/monge_elkan.py
`sim = float(sum_of_maxes) / float(len(bag1)) `
which is essentially the mean max.

But in the implementation for textdistance, the score is given on line 222 of
https://github.com/life4/textdistance/blob/master/textdistance/algorithms/token_based.py as  
`sum(maxes) / len(seq) / len(maxes)`

I think the further division by len(maxes) isn't needed,
and the line should just be 
`sum(maxes) / len(seq)`

The change in the code could mess up tests elsewhere,
so I'm not changing anything else. But thought
I should bring this to your attention.

Below is some code and differing scores I got in 
textdistance and py_stringmatching.
```
# score in textdistance
from textdistance import MongeElkan, levenshtein
ALG = MongeElkan
score = ALG(algorithm=levenshtein,qval=None,symmetric=False).similarity('Good Times!', "The Good Times and The Bad Ones")
score
# Got 2.25
```
```
#score in py_stringmatching
from py_stringmatching import MongeElkan
from py_stringmatching import Levenshtein as Levenshtein_2
ALG_2 = MongeElkan(sim_func=Levenshtein_2().get_raw_score)
source = 'Good Times!'
source_split = source.split()
target = "The Good Times and The Bad Ones"
target_split = target.split()
score2 = ALG_2.get_raw_score(source_split, target_split)
score2
# got 5.5
```