### PR TITLE
update rapidfuzz

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ extras = {
         'numpy',                    # for SmithWaterman and other
         'python-Levenshtein',       # for Jaro and Levenshtein
         'pyxDamerauLevenshtein',    # for DamerauLevenshtein
-        'rapidfuzz>=2.0.0',         # for Jaro, Levenshtein and other
+        'rapidfuzz>=2.6.0',         # for Jaro, Levenshtein and other
     ],
 
     # needed for benchmarking, optimization and testing
@@ -23,7 +23,7 @@ extras = {
         'numpy',
         'python-Levenshtein',
         'pyxDamerauLevenshtein',
-        'rapidfuzz>=2.0.0',
+        'rapidfuzz>=2.6.0',
         # slow
         'distance',
         'pylev',
@@ -40,26 +40,27 @@ extras = {
 
     # for algos, from fastest to slowest, only faster than textdistance:
     'DamerauLevenshtein': [
+        'rapidfuzz>=2.6.0',         # any iterators of hashable elements
         'jellyfish',                # only for text
         'pyxDamerauLevenshtein',    # for any iterators
     ],
     'Hamming': [
         'python-Levenshtein',   # only same length and strings
-        'rapidfuzz>=2.0.0',     # only same length, any iterators of hashable elements
+        'rapidfuzz>=2.6.0',     # only same length, any iterators of hashable elements
         'jellyfish',            # only strings, any length
         'distance',             # only same length, any iterators
         'abydos',               # any iterators
     ],
     'Jaro': [
-        'rapidfuzz>=2.0.0',     # any iterators of hashable elements
+        'rapidfuzz>=2.6.0',     # any iterators of hashable elements
         'python-Levenshtein',   # only text
     ],
     'JaroWinkler': [
-        'rapidfuzz>=2.0.0',     # any iterators of hashable elements
+        'rapidfuzz>=2.6.0',     # any iterators of hashable elements
         'jellyfish',            # only text
     ],
     'Levenshtein': [
-        'rapidfuzz>=2.0.0',     # any iterators of hashable elements
+        'rapidfuzz>=2.6.0',     # any iterators of hashable elements
         'python-Levenshtein',   # only text
         # yeah, other libs slower than textdistance
     ],

--- a/textdistance/libraries.json
+++ b/textdistance/libraries.json
@@ -1,6 +1,10 @@
 {
   "DamerauLevenshtein": [
     [
+      "rapidfuzz.distance.DamerauLevenshtein",
+      "distance"
+    ],
+    [
       "jellyfish",
       "damerau_levenshtein_distance"
     ],

--- a/textdistance/libraries.py
+++ b/textdistance/libraries.py
@@ -154,6 +154,7 @@ prototype = LibrariesManager()
 prototype.register('DamerauLevenshtein', LibraryBase('abydos.distance', 'DamerauLevenshtein'))
 prototype.register('DamerauLevenshtein', LibraryBase('pyxdameraulevenshtein', 'damerau_levenshtein_distance'))
 prototype.register('DamerauLevenshtein', TextLibrary('jellyfish', 'damerau_levenshtein_distance'))
+prototype.register('DamerauLevenshtein', LibraryBase('rapidfuzz.distance.DamerauLevenshtein', 'distance'))
 
 prototype.register('Hamming', LibraryBase('abydos.distance', 'Hamming'))
 prototype.register('Hamming', SameLengthLibrary('distance', 'hamming'))


### PR DESCRIPTION
update rapidfuzz to the latest version which provides a damerau levenshtein implementation. It is the fastest of the supported libraries:
```
| algorithm          | library                               | function                     |        time |
|--------------------+---------------------------------------+------------------------------+-------------|
| DamerauLevenshtein | rapidfuzz.distance.DamerauLevenshtein | distance                     | 0.00267046  |
| DamerauLevenshtein | jellyfish                             | damerau_levenshtein_distance | 0.022479    |
| DamerauLevenshtein | pyxdameraulevenshtein                 | damerau_levenshtein_distance | 0.0393475   |
| DamerauLevenshtein | **textdistance**                      | DamerauLevenshtein           | 0.589098    |
```
In addition it is the only implementation which only requires linear memory.