### PR TITLE
Replace deprecated license_file with license_files in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 description_file = README.md
-license_file = LICENSE
+license_files = LICENSE
 
 [flake8]
 max-line-length=120


### PR DESCRIPTION
Fixes:

```
  /usr/lib/python3.12/site-packages/setuptools/config/setupcfg.py:293: _DeprecatedConfig: Deprecated config in `setup.cfg`
  !!

          ********************************************************************************
          The license_file parameter is deprecated, use license_files instead.

          By 2023-Oct-30, you need to update your project and remove deprecated calls
          or your builds will no longer be supported.  

          See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
          ********************************************************************************

  !!
```