### PR TITLE
Levenstein distance output type normalization

### DIFF
--- a/textdistance/algorithms/edit_based.py
+++ b/textdistance/algorithms/edit_based.py
@@ -126,7 +126,7 @@ class Levenshtein(_Base):
                 dist = self.test_func(s1[r - 1], s2[c - 1])
                 edit = prev[c - 1] + (not dist)
                 cur[c] = min(edit, deletion, insertion)
-        return cur[-1]
+        return int(cur[-1])
 
     def __call__(self, s1: Sequence[T], s2: Sequence[T]) -> int:
         s1, s2 = self._get_sequences(s1, s2)


### PR DESCRIPTION
- notmalize integer output, since cur may contain both int and np.int32 dtypes. 
- If int32 is returned FastAPI can't serialize this type.

![2024-04-24_102127_Levenstein Distance bug 2](https://github.com/life4/textdistance/assets/11719581/71cef879-4d02-4887-91ae-c5e1ce6463db)
