### PR TITLE
Fix spelling and add missing import

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Features:
 | Algorithm                                                                                 | Class                | Functions              |
 |-------------------------------------------------------------------------------------------|----------------------|------------------------|
 | [Hamming](https://en.wikipedia.org/wiki/Hamming_distance)                                 | `Hamming`            | `hamming`              |
-| [MLIPNS](http://www.sial.iias.spb.su/files/386-386-1-PB.pdf)                              | `Mlipns`             | `mlipns`               |
+| [MLIPNS](http://www.sial.iias.spb.su/files/386-386-1-PB.pdf)                              | `MLIPNS`             | `mlipns`               |
 | [Levenshtein](https://en.wikipedia.org/wiki/Levenshtein_distance)                         | `Levenshtein`        | `levenshtein`          |
 | [Damerau-Levenshtein](https://en.wikipedia.org/wiki/Damerau%E2%80%93Levenshtein_distance) | `DamerauLevenshtein` | `damerau_levenshtein`  |
 | [Jaro-Winkler](https://en.wikipedia.org/wiki/Jaro%E2%80%93Winkler_distance)               | `JaroWinkler`        | `jaro_winkler`, `jaro` |

--- a/textdistance/algorithms/token_based.py
+++ b/textdistance/algorithms/token_based.py
@@ -15,7 +15,7 @@ __all__ = [
     'Jaccard', 'Sorensen', 'Tversky',
     'Overlap', 'Cosine', 'Tanimoto', 'MongeElkan', 'Bag',
 
-    'jaccard', 'sorensen', 'tversky', 'sorensen_dice',
+    'jaccard', 'sorensen', 'tversky', 'sorensen_dice', 'dice',
     'overlap', 'cosine', 'tanimoto', 'monge_elkan', 'bag',
 ]
 


### PR DESCRIPTION
- The spelling of the `MLIPNS` class in the readme was wrong.
- The readme listed the function `dice`, which was not exported.