### PR TITLE
Remove support for unmaintained "distance" library

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,6 @@ hamming('text', 'testit')
 
 Supported libraries:
 
-1. [Distance](https://github.com/doukremt/distance)
 1. [jellyfish](https://github.com/jamesturk/jellyfish)
 1. [py_stringmatching](https://github.com/anhaidgroup/py_stringmatching)
 1. [pylev](https://github.com/toastdriven/pylev)
@@ -248,7 +247,6 @@ Without extras installation:
 | Hamming            | Levenshtein           | 0.00038 |
 | Hamming            | rapidfuzz             | 0.00044 |
 | Hamming            | jellyfish             | 0.00091 |
-| Hamming            | distance              | 0.00812 |
 | Hamming            | **textdistance**      | 0.03531 |
 | Jaro               | rapidfuzz             | 0.00092 |
 | Jaro               | jellyfish             | 0.00191 |
@@ -260,7 +258,6 @@ Without extras installation:
 | Levenshtein        | Levenshtein           | 0.00122 |
 | Levenshtein        | jellyfish             | 0.00254 |
 | Levenshtein        | pylev                 | 0.15688 |
-| Levenshtein        | distance              | 0.28669 |
 | Levenshtein        | **textdistance**      | 0.53902 |
 
 Total: 24 libs.

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ extras = {
         'pyxDamerauLevenshtein',
         'rapidfuzz>=2.6.0',
         # slow
-        'distance',
         'pylev',
         'py_stringmatching',
         # other
@@ -65,7 +64,6 @@ extras = {
         'Levenshtein',          # only same length and strings
         'rapidfuzz>=2.6.0',     # only same length, any iterators of hashable elements
         'jellyfish',            # only strings, any length
-        'distance',             # only same length, any iterators
     ],
     'Jaro': [
         'rapidfuzz>=2.6.0',     # any iterators of hashable elements

--- a/textdistance/libraries.json
+++ b/textdistance/libraries.json
@@ -29,10 +29,6 @@
     [
       "jellyfish",
       "hamming_distance"
-    ],
-    [
-      "distance",
-      "hamming"
     ]
   ],
   "Jaro": [
@@ -70,10 +66,6 @@
     ],
     [
       "pylev",
-      "levenshtein"
-    ],
-    [
-      "distance",
       "levenshtein"
     ]
   ]

--- a/textdistance/libraries.py
+++ b/textdistance/libraries.py
@@ -173,7 +173,6 @@ reg(alg, LibraryBase('rapidfuzz.distance.DamerauLevenshtein', 'distance', condit
 reg(alg, LibraryBase('rapidfuzz.distance.OSA', 'distance', conditions=dict(restricted=True)))
 
 alg = 'Hamming'
-reg(alg, SameLengthLibrary('distance', 'hamming'))
 reg(alg, SameLengthTextLibrary('Levenshtein', 'hamming'))
 reg(alg, TextLibrary('jellyfish', 'hamming_distance'))
 reg(alg, SameLengthLibrary('rapidfuzz.distance.Hamming', 'distance'))
@@ -192,7 +191,6 @@ reg(alg, LibraryBase('rapidfuzz.distance.JaroWinkler', 'similarity', conditions=
 # reg(alg, TextLibrary('Levenshtein', 'jaro_winkler', conditions=dict(winklerize=True)))
 
 alg = 'Levenshtein'
-reg(alg, LibraryBase('distance', 'levenshtein'))
 reg(alg, LibraryBase('pylev', 'levenshtein'))
 reg(alg, TextLibrary('jellyfish', 'levenshtein_distance'))
 reg(alg, TextLibrary('Levenshtein', 'distance'))


### PR DESCRIPTION
textdistance supports the "distance" library for two algorithms, but this package is unmaintained (last update about 11 years ago), and the C extension (which presumably made it faster than the pure Python implementation of textdistance) does not compile with recent Python releases.  This PR drops support for this library and mention of it in the README file.